### PR TITLE
Feature/edit saved color palette lm

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -13,10 +13,9 @@ var savedPalettesMessage = document.querySelector(".saved-palettes-message");
 // ===== GLOBAL VARIABLES =====
 var currentColorPalette = {
   colors: [],
-  id: Date.now(),
 };
 
-var savedColorPalette = []
+var savedColorPalette = [];
 // ===== ORIGINAL SPEC COLORS =====
 //     { hexCode: "#EA9999", status: "locked", id: 1690287923557 },
 //     { hexCode: "#FACB9C", status: "locked", id: 1690287923557 },
@@ -46,7 +45,12 @@ savePaletteButton.addEventListener("click", function () {
   displaySavedPalette(savedColorPalette, savedColorsContainer);
   setCurrentColors(currentColorPalette);
   displayCurrentColorPalette();
-})
+});
+
+savedColorsContainer.addEventListener("click", function (event) {
+  deleteSavedPalette(event);
+  displaySavedPalette(savedColorPalette, savedColorsContainer);
+});
 
 // ===== FUNCTIONS =====
 
@@ -75,7 +79,7 @@ function createColor() {
 }
 
 function setCurrentColors(
-  currentColorPalette,
+  currentColorPalette
   // savedColorPalette = { colors: [], id: Date.now() }
 ) {
   // if (savedColorPalette.colors.length) {
@@ -93,6 +97,7 @@ function setCurrentColors(
       }
     }
   }
+  currentColorPalette.id = Date.now();
 }
 
 // }
@@ -136,9 +141,8 @@ function savePalette(palette) {
   savedColorPalette.push(savedPalette);
 }
 
-
 function displaySavedPalette(savedColorPalette, savedColorsContainer) {
-  savedColorsContainer.innerHTML = ""
+  savedColorsContainer.innerHTML = "";
   for (var i = 0; i < savedColorPalette.length; i++) {
     savedColorsContainer.innerHTML += `<div class="layer"> 
    <div class="saved-color-box" style="background-color: ${savedColorPalette[i].colors[0].hexCode}"></div>
@@ -146,10 +150,22 @@ function displaySavedPalette(savedColorPalette, savedColorsContainer) {
    <div class="saved-color-box" style="background-color: ${savedColorPalette[i].colors[2].hexCode}"></div>
    <div class="saved-color-box" style="background-color: ${savedColorPalette[i].colors[3].hexCode}"></div>
    <div class="saved-color-box" style="background-color: ${savedColorPalette[i].colors[4].hexCode}"></div>
+   <img id="${savedColorPalette[i].id}"class="image delete"src='assets/delete.png'>
     </div>`;
   }
 }
 
-function hideElement(message){
+function deleteSavedPalette(event) {
+  var deletePalette = event.target.id;
+  var index;
+  for (let i = 0; i < savedColorPalette.length; i++) {
+    if (savedColorPalette[i].id.toString() === deletePalette) {
+      index = i;
+    }
+  }
+  savedColorPalette.splice(index, 1);
+}
+
+function hideElement(message) {
   message.classList.toggle("hidden", true);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -50,6 +50,7 @@ savePaletteButton.addEventListener("click", function () {
 savedColorsContainer.addEventListener("click", function (event) {
   deleteSavedPalette(event);
   displaySavedPalette(savedColorPalette, savedColorsContainer);
+  displayCurrentColorPalette(currentColorPalette);
 });
 
 // ===== FUNCTIONS =====
@@ -78,10 +79,7 @@ function createColor() {
   return color;
 }
 
-function setCurrentColors(
-  currentColorPalette
-  // savedColorPalette = { colors: [], id: Date.now() }
-) {
+function setCurrentColors(currentColorPalette, savedColorPalette) {
   // if (savedColorPalette.colors.length) {
   //   currentColorPalette = savedColorPalette;
   // } else {
@@ -99,7 +97,6 @@ function setCurrentColors(
   }
   currentColorPalette.id = Date.now();
 }
-
 // }
 
 function displayCurrentColorPalette() {
@@ -144,7 +141,7 @@ function savePalette(palette) {
 function displaySavedPalette(savedColorPalette, savedColorsContainer) {
   savedColorsContainer.innerHTML = "";
   for (var i = 0; i < savedColorPalette.length; i++) {
-    savedColorsContainer.innerHTML += `<div class="layer"> 
+    savedColorsContainer.innerHTML += `<div class="layer" > 
    <div class="saved-color-box" style="background-color: ${savedColorPalette[i].colors[0].hexCode}"></div>
    <div class="saved-color-box" style="background-color: ${savedColorPalette[i].colors[1].hexCode}"></div>
    <div class="saved-color-box" style="background-color: ${savedColorPalette[i].colors[2].hexCode}"></div>
@@ -156,16 +153,24 @@ function displaySavedPalette(savedColorPalette, savedColorsContainer) {
 }
 
 function deleteSavedPalette(event) {
-  var deletePalette = event.target.id;
-  var index;
+  var deletePalette = event.target;
+  console.log(deletePalette);
   for (let i = 0; i < savedColorPalette.length; i++) {
-    if (savedColorPalette[i].id.toString() === deletePalette) {
-      index = i;
+    if (
+      savedColorPalette[i].id.toString() === deletePalette.id &&
+      deletePalette.classList.contains("delete")
+    ) {
+      savedColorPalette.splice(i, 1);
     }
   }
-  savedColorPalette.splice(index, 1);
 }
 
 function hideElement(message) {
   message.classList.toggle("hidden", true);
+}
+
+
+function editSavedPalette(event) {
+  var editPalette = event.target;
+  console.log(editPalette);
 }

--- a/styles.css
+++ b/styles.css
@@ -88,6 +88,10 @@
   margin: 5px;
 }
 
+.delete {
+  margin-top: 30px;
+}
+
 .saved-palettes-container {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Description:
- This PR includes the delete saved palette functionality and iteration 5

## Functionality/Changes: 
- deleteSavedPalette functionality 
- moving the id assignment of current palette out of the 'constructor' data model and into the setCurrentColorPalette function 
- minor css tweaks

## Type of change:
- [x] New feature
- [x] Bug Fix

## Checklist:
- My code has limited unused/commented out code
- I have reviewed my code
- I have commented my code, particularly in hard-to-understand areas
- I have fully tested my code

## Please Include a link to a gif of your feelings about this branch: 
![](At the end)](https://media.giphy.com/media/26u4lOMA8JKSnL9Uk/giphy.gif)